### PR TITLE
ResourcePointer: Fix move constructor, assignment

### DIFF
--- a/include/Core/ResourcePointer.tcc
+++ b/include/Core/ResourcePointer.tcc
@@ -29,7 +29,10 @@ ResourcePointer<T_Resource>::ResourcePointer(ResourcePointer<T_Resource>&& resou
     _resource(resourcePointer._resource),
     _resourceId(resourcePointer._resourceId)
 {
-    resourcePointer._resource = nullptr;
+    if (resourcePointer._resource) {
+        _unRegisterPointer(&resourcePointer);
+        resourcePointer._resource = nullptr;
+    }
     if (_resource)
         _registerPointer(this);
 }
@@ -62,10 +65,12 @@ ResourcePointer<T_Resource>& ResourcePointer<T_Resource>::operator=(ResourcePoin
     _resource = resourcePointer._resource;
     _resourceId = resourcePointer._resourceId;
 
+    if (resourcePointer._resource) {
+        _unRegisterPointer(&resourcePointer);
+        resourcePointer._resource = nullptr;
+    }
     if (_resource)
         _registerPointer(this);
-
-    resourcePointer._resource = nullptr;
 
     return *this;
 }


### PR DESCRIPTION
The temporary pointer should be unregistered after move